### PR TITLE
Bugfix/edit det track status messages

### DIFF
--- a/vista/widgets/core/data/aois_panel.py
+++ b/vista/widgets/core/data/aois_panel.py
@@ -3,7 +3,7 @@
 import pathlib
 
 import pandas as pd
-from PyQt6.QtCore import QSettings, Qt, pyqtSignal
+from PyQt6.QtCore import QSettings, Qt
 from PyQt6.QtGui import QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QFileDialog,
@@ -15,18 +15,16 @@ from PyQt6.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
-    QWidget,
 )
 
+from vista.widgets.core.data.data_panel import DataPanel
 
-class AOIsPanel(QWidget):
+
+class AOIsPanel(DataPanel):
     """Panel for managing Areas of Interest (AOIs)"""
 
-    data_changed = pyqtSignal()  # Signal when data is modified
-
     def __init__(self, viewer):
-        super().__init__()
-        self.viewer = viewer
+        super().__init__(viewer)
         self.settings = QSettings("VISTA", "VISTA")
         self.init_ui()
 

--- a/vista/widgets/core/data/data_panel.py
+++ b/vista/widgets/core/data/data_panel.py
@@ -1,0 +1,22 @@
+"""Shared base class for data manager panels."""
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import QWidget
+
+
+class DataPanel(QWidget):
+    """Base class for the data manager tab panels.
+
+    Holds the viewer reference and the signals every panel shares. Panels
+    emit status_message instead of reaching for the main window's status bar
+    through the widget hierarchy (panels are reparented by QTabWidget.addTab,
+    so self.parent() chains do not lead where they appear to).
+    """
+
+    data_changed = pyqtSignal()  # Signal when data is modified
+    files_dropped = pyqtSignal(list)  # Emits list of file paths dropped onto the panel
+    status_message = pyqtSignal(str, int)  # Message text + timeout ms for the status bar
+
+    def __init__(self, viewer, parent=None):
+        super().__init__(parent)
+        self.viewer = viewer

--- a/vista/widgets/core/data/data_panel.py
+++ b/vista/widgets/core/data/data_panel.py
@@ -5,17 +5,11 @@ from PyQt6.QtWidgets import QWidget
 
 
 class DataPanel(QWidget):
-    """Base class for the data manager tab panels.
+    """Base class for the data manager tab panels."""
 
-    Holds the viewer reference and the signals every panel shares. Panels
-    emit status_message instead of reaching for the main window's status bar
-    through the widget hierarchy (panels are reparented by QTabWidget.addTab,
-    so self.parent() chains do not lead where they appear to).
-    """
-
-    data_changed = pyqtSignal()  # Signal when data is modified
-    files_dropped = pyqtSignal(list)  # Emits list of file paths dropped onto the panel
-    status_message = pyqtSignal(str, int)  # Message text + timeout ms for the status bar
+    data_changed = pyqtSignal()
+    files_dropped = pyqtSignal(list)
+    status_message = pyqtSignal(str, int)
 
     def __init__(self, viewer, parent=None):
         super().__init__(parent)

--- a/vista/widgets/core/data/detections_panel.py
+++ b/vista/widgets/core/data/detections_panel.py
@@ -5,7 +5,7 @@ import traceback
 
 import numpy as np
 import pandas as pd
-from PyQt6.QtCore import QEvent, QItemSelectionModel, QSettings, Qt, pyqtSignal
+from PyQt6.QtCore import QEvent, QItemSelectionModel, QSettings, Qt
 from PyQt6.QtGui import QAction, QBrush, QColor
 from PyQt6.QtWidgets import (
     QApplication,
@@ -33,6 +33,7 @@ from PyQt6.QtWidgets import (
 from vista.tracks.track import Track
 from vista.utils.color import pg_color_to_qcolor, qcolor_to_pg_color
 from vista.utils.labeler import get_current_label_time, get_current_labeler
+from vista.widgets.core.data.data_panel import DataPanel
 from vista.widgets.core.data.delegates import (
     ColorDelegate,
     LabelsDelegate,
@@ -47,16 +48,12 @@ from vista.widgets.core.data.undo_manager import UndoStack
 _CSV_EXTENSIONS = (".csv",)
 
 
-class DetectionsPanel(QWidget):
+class DetectionsPanel(DataPanel):
     """Panel for managing detections"""
 
-    data_changed = pyqtSignal()  # Signal when data is modified
-    files_dropped = pyqtSignal(list)  # Emits list of file paths dropped onto the panel
-
     def __init__(self, viewer):
-        super().__init__()
+        super().__init__(viewer)
         self.settings = QSettings("VISTA", "DataManager")
-        self.viewer = viewer
         self.selected_detections = []  # List of tuples: [(detector, frame, index), ...]
         self.waiting_for_track_selection = False  # Flag when waiting for user to select track
         self.init_ui()
@@ -1271,38 +1268,25 @@ class DetectionsPanel(QWidget):
 
             # Start detector editing mode
             self.viewer.start_detection_editing(detector)
-            # Update main window status
-            if hasattr(self.parent(), "parent"):
-                main_window = self.parent().parent()
-                if hasattr(main_window, "statusBar"):
-                    main_window.statusBar().showMessage(
-                        f"Detector editing mode: Click to add detections or click existing detections to remove them for '{detector.name}'. Only current frame shown. Uncheck 'Edit Detector' when finished.",
-                        0,
-                    )
+            self.status_message.emit(
+                "Detector editing mode: Click to add detections or click existing detections to remove them for "
+                f"'{detector.name}'. Only current frame shown. Uncheck 'Edit Detector' when finished.",
+                0,
+            )
         else:
             # Finish detector editing
             edited_detector = self.viewer.finish_detection_editing()
             if edited_detector:
-                # Refresh the panel (need to access parent's refresh method)
-                parent = self.parent()
-                if parent and hasattr(parent, "refresh"):
-                    parent.refresh()
-                # Update main window status
-                if hasattr(self.parent(), "parent"):
-                    main_window = self.parent().parent()
-                    if hasattr(main_window, "statusBar"):
-                        total_detections = len(edited_detector.frames)
-                        unique_frames = len(np.unique(edited_detector.frames))
-                        main_window.statusBar().showMessage(
-                            f"Detector '{edited_detector.name}' updated with {total_detections} detections across {unique_frames} frames",
-                            3000,
-                        )
+                self.refresh_detections_table()
+                total_detections = len(edited_detector.frames)
+                unique_frames = len(np.unique(edited_detector.frames))
+                self.status_message.emit(
+                    f"Detector '{edited_detector.name}' updated with {total_detections} detections across "
+                    f"{unique_frames} frames",
+                    3000,
+                )
             else:
-                # Update main window status
-                if hasattr(self.parent(), "parent"):
-                    main_window = self.parent().parent()
-                    if hasattr(main_window, "statusBar"):
-                        main_window.statusBar().showMessage("Detector editing cancelled", 3000)
+                self.status_message.emit("Detector editing cancelled", 3000)
 
     def export_detections(self):
         """Export selected detections to CSV file"""
@@ -1730,9 +1714,7 @@ class DetectionsPanel(QWidget):
         self.add_to_existing_track_btn.clicked.connect(self.cancel_add_to_existing_track)
 
         # Show status message
-        main_window = QApplication.instance().activeWindow()
-        if hasattr(main_window, "statusBar"):
-            main_window.statusBar().showMessage("Click on a track in the viewer to add selected detections to it", 0)
+        self.status_message.emit("Click on a track in the viewer to add selected detections to it", 0)
 
     def cancel_add_to_existing_track(self):
         """Cancel adding detections to an existing track"""
@@ -1749,9 +1731,7 @@ class DetectionsPanel(QWidget):
         self.add_to_existing_track_btn.clicked.connect(self.start_add_to_existing_track)
 
         # Clear status message
-        main_window = QApplication.instance().activeWindow()
-        if hasattr(main_window, "statusBar"):
-            main_window.statusBar().showMessage("Add to track cancelled", 3000)
+        self.status_message.emit("Add to track cancelled", 3000)
 
     def on_track_selected_for_adding_detections(self, track):
         """Handle track selection when adding detections to existing track"""

--- a/vista/widgets/core/data/features_panel.py
+++ b/vista/widgets/core/data/features_panel.py
@@ -1,6 +1,6 @@
 """Features panel for data manager"""
 
-from PyQt6.QtCore import QSettings, Qt, pyqtSignal
+from PyQt6.QtCore import QSettings, Qt
 from PyQt6.QtGui import QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QCheckBox,
@@ -15,18 +15,16 @@ from PyQt6.QtWidgets import (
 )
 
 from vista.features import PlacemarkFeature
+from vista.widgets.core.data.data_panel import DataPanel
 
 from .placemark_dialog import PlacemarkDialog
 
 
-class FeaturesPanel(QWidget):
+class FeaturesPanel(DataPanel):
     """Panel for managing persistent features (shapefiles, placemarks, etc.)"""
 
-    data_changed = pyqtSignal()  # Signal when data is modified
-
     def __init__(self, viewer):
-        super().__init__()
-        self.viewer = viewer
+        super().__init__(viewer)
         self.settings = QSettings("VISTA", "VISTA")
         self.init_ui()
 

--- a/vista/widgets/core/data/imagery_panel.py
+++ b/vista/widgets/core/data/imagery_panel.py
@@ -15,20 +15,18 @@ from PyQt6.QtWidgets import (
 )
 
 from vista.imagery.imagery import HAS_TORCH
+from vista.widgets.core.data.data_panel import DataPanel
 
 _HDF5_EXTENSIONS = (".h5", ".hdf5")
 
 
-class ImageryPanel(QWidget):
+class ImageryPanel(DataPanel):
     """Panel for managing imagery"""
 
-    data_changed = pyqtSignal()  # Signal when data is modified
     cancel_loading_requested = pyqtSignal(object)  # Emits imagery UUID to cancel loading
-    files_dropped = pyqtSignal(list)  # Emits list of file paths dropped onto the panel
 
     def __init__(self, viewer):
-        super().__init__()
-        self.viewer = viewer
+        super().__init__(viewer)
         self.init_ui()
 
     def init_ui(self):

--- a/vista/widgets/core/data/sensors_panel.py
+++ b/vista/widgets/core/data/sensors_panel.py
@@ -9,23 +9,21 @@ from PyQt6.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
-    QWidget,
 )
+
+from vista.widgets.core.data.data_panel import DataPanel
 
 _HDF5_EXTENSIONS = (".h5", ".hdf5")
 
 
-class SensorsPanel(QWidget):
+class SensorsPanel(DataPanel):
     """Panel for managing sensors"""
 
-    data_changed = pyqtSignal()  # Signal when data is modified
     sensor_selected = pyqtSignal(object)  # Signal when sensor selection changes
     cancel_sensor_loading_requested = pyqtSignal(object)  # Emits sensor being deleted (to cancel loading imagery)
-    files_dropped = pyqtSignal(list)  # Emits list of file paths dropped onto the panel
 
     def __init__(self, viewer):
-        super().__init__()
-        self.viewer = viewer
+        super().__init__(viewer)
         self.init_ui()
 
     def init_ui(self):

--- a/vista/widgets/core/data/tracks_panel.py
+++ b/vista/widgets/core/data/tracks_panel.py
@@ -4,7 +4,7 @@ import pathlib
 
 import numpy as np
 import pandas as pd
-from PyQt6.QtCore import QEvent, QSettings, Qt, pyqtSignal
+from PyQt6.QtCore import QEvent, QSettings, Qt
 from PyQt6.QtGui import QAction, QBrush, QColor
 from PyQt6.QtWidgets import (
     QApplication,
@@ -39,6 +39,7 @@ from vista.tracks.track import Track
 from vista.utils.color import pg_color_to_qcolor, qcolor_to_pg_color
 from vista.utils.labeler import get_current_label_time, get_current_labeler
 from vista.widgets.algorithms.tracks.extraction_dialog import TrackExtractionDialog
+from vista.widgets.core.data.data_panel import DataPanel
 from vista.widgets.core.data.delegates import (
     ColorDelegate,
     LabelsDelegate,
@@ -286,15 +287,11 @@ class OrderByDialog(QDialog):
 _CSV_EXTENSIONS = (".csv",)
 
 
-class TracksPanel(QWidget):
+class TracksPanel(DataPanel):
     """Panel for managing tracks"""
 
-    data_changed = pyqtSignal()  # Signal when data is modified
-    files_dropped = pyqtSignal(list)  # Emits list of file paths dropped onto the panel
-
     def __init__(self, viewer):
-        super().__init__()
-        self.viewer = viewer
+        super().__init__(viewer)
         self.settings = QSettings("VISTA", "DataManager")
 
         # Track plot windows (multiple windows allowed)
@@ -2470,35 +2467,21 @@ class TracksPanel(QWidget):
 
             # Start track editing mode
             self.viewer.start_track_editing(track)
-            # Update main window status
-            if hasattr(self.parent(), "parent"):
-                main_window = self.parent().parent()
-                if hasattr(main_window, "statusBar"):
-                    main_window.statusBar().showMessage(
-                        f"Track editing mode: Click on frames to add/move track points for '{track.name}'. Uncheck 'Edit Track' when finished.",
-                        0,
-                    )
+            self.status_message.emit(
+                f"Track editing mode: Click on frames to add/move track points for '{track.name}'. "
+                "Uncheck 'Edit Track' when finished.",
+                0,
+            )
         else:
             # Finish track editing
             edited_track = self.viewer.finish_track_editing()
             if edited_track:
-                # Refresh the panel (need to access parent's refresh method)
-                parent = self.parent()
-                if parent and hasattr(parent, "refresh"):
-                    parent.refresh()
-                # Update main window status
-                if hasattr(self.parent(), "parent"):
-                    main_window = self.parent().parent()
-                    if hasattr(main_window, "statusBar"):
-                        main_window.statusBar().showMessage(
-                            f"Track '{edited_track.name}' updated with {len(edited_track.frames)} points", 3000
-                        )
+                self.refresh_tracks_table()
+                self.status_message.emit(
+                    f"Track '{edited_track.name}' updated with {len(edited_track.frames)} points", 3000
+                )
             else:
-                # Update main window status
-                if hasattr(self.parent(), "parent"):
-                    main_window = self.parent().parent()
-                    if hasattr(main_window, "statusBar"):
-                        main_window.statusBar().showMessage("Track editing cancelled", 3000)
+                self.status_message.emit("Track editing cancelled", 3000)
 
     def manage_labels(self):
         """Open the labels manager dialog"""
@@ -2617,9 +2600,7 @@ class TracksPanel(QWidget):
             self.on_view_extraction_clicked(True)
 
         # Show status message
-        main_window = self.window()
-        if hasattr(main_window, "statusBar"):
-            main_window.statusBar().showMessage(f"Successfully extracted {len(tracks)} track(s)", 3000)
+        self.status_message.emit(f"Successfully extracted {len(tracks)} track(s)", 3000)
 
     def on_view_extraction_clicked(self, checked):
         """Handle View Extraction button click"""
@@ -2661,20 +2642,15 @@ class TracksPanel(QWidget):
                 self.view_extraction_btn.setChecked(False)
                 return
 
-            # Update main window status
-            if hasattr(main_window, "statusBar"):
-                main_window.statusBar().showMessage(
-                    f"Viewing extraction for '{track.name}'. Signal pixels shown in red. Uncheck 'View Extraction' when finished.",
-                    0,
-                )
+            self.status_message.emit(
+                f"Viewing extraction for '{track.name}'. Signal pixels shown in red. "
+                "Uncheck 'View Extraction' when finished.",
+                0,
+            )
         else:
             # Finish extraction viewing
             self.viewer.finish_extraction_viewing()
-
-            # Update main window status
-            main_window = self.window()
-            if hasattr(main_window, "statusBar"):
-                main_window.statusBar().showMessage("Extraction viewing ended", 3000)
+            self.status_message.emit("Extraction viewing ended", 3000)
 
     def on_edit_extraction_clicked(self, checked):
         """Handle Edit Extraction button click"""
@@ -2733,12 +2709,11 @@ class TracksPanel(QWidget):
                 self.edit_extraction_btn.setChecked(False)
                 return
 
-            # Update main window status
-            if hasattr(main_window, "statusBar"):
-                main_window.statusBar().showMessage(
-                    f"Editing extraction for '{track.name}'. Click to paint/erase signal pixels. Use the editor panel to adjust settings.",
-                    0,
-                )
+            self.status_message.emit(
+                f"Editing extraction for '{track.name}'. Click to paint/erase signal pixels. "
+                "Use the editor panel to adjust settings.",
+                0,
+            )
         else:
             # Finish extraction editing
             self.viewer.finish_extraction_editing()
@@ -2746,11 +2721,7 @@ class TracksPanel(QWidget):
             # Refresh the table to update SNR if changed
             self.refresh_tracks_table()
             self.data_changed.emit()
-
-            # Update main window status
-            main_window = self.window()
-            if hasattr(main_window, "statusBar"):
-                main_window.statusBar().showMessage("Extraction editing ended", 3000)
+            self.status_message.emit("Extraction editing ended", 3000)
 
     def on_extraction_editing_ended(self):
         """Handle extraction editing ended signal from viewer"""

--- a/vista/widgets/core/main_window.py
+++ b/vista/widgets/core/main_window.py
@@ -136,6 +136,17 @@ class VistaMainWindow(QMainWindow):
         self.data_manager.imagery_panel.cancel_loading_requested.connect(self.on_cancel_imagery_loading)
         self.data_manager.sensors_panel.cancel_sensor_loading_requested.connect(self.on_cancel_sensor_loading)
 
+        # Route panel status messages to the status bar
+        for panel in (
+            self.data_manager.sensors_panel,
+            self.data_manager.imagery_panel,
+            self.data_manager.tracks_panel,
+            self.data_manager.detections_panel,
+            self.data_manager.aois_panel,
+            self.data_manager.features_panel,
+        ):
+            panel.status_message.connect(self.statusBar().showMessage)
+
         # Connect sensor selection to map view state updates
         self.data_manager.sensors_panel.sensor_selected.connect(lambda _sensor: self._update_map_view_action_state())
 


### PR DESCRIPTION
There are multiple places where the widget tree is walked up to find the main window instead of using a signal/slot to update the status bar. At-least two instances of this result in status messages not being updated because they don't call `.parent()` enough times.

Adds a base `DataPanel` class for panels to inherit from. The DataPanel provides common signals for the widget panels. The signals are registered in the main on the main window. 

There's also some shared code between the panels, and the DataPanel would be a good place to extract some of that in that in the future.

resolves #22 
