### PR TITLE
hide paths and markers for tracks that don't match the current sensor

### DIFF
--- a/vista/widgets/core/data/data_manager.py
+++ b/vista/widgets/core/data/data_manager.py
@@ -64,6 +64,8 @@ class DataManagerPanel(QWidget):
         # refresh detections panel when tracks are created
         self.tracks_panel.data_changed.connect(self.detections_panel.refresh_detections_table)
 
+        self.detections_panel.data_changed.connect(self.tracks_panel.refresh_tracks_table)
+
         # Add panels as tabs
         self.tabs.addTab(self.sensors_panel, "Sensors")
         self.tabs.addTab(self.imagery_panel, "Imagery")

--- a/vista/widgets/core/data/detections_panel.py
+++ b/vista/widgets/core/data/detections_panel.py
@@ -1661,15 +1661,6 @@ class DetectionsPanel(DataPanel):
         # Clear selection
         self.clear_detection_selection()
 
-        # Explicitly refresh the tracks table to show the new track
-        # Get the tracks panel from the parent data manager
-        parent_widget = self.parent()
-        while parent_widget is not None:
-            if hasattr(parent_widget, "tracks_panel"):
-                parent_widget.tracks_panel.refresh_tracks_table()
-                break
-            parent_widget = parent_widget.parent()
-
         self.data_changed.emit()
 
         # Exit detection selection mode

--- a/vista/widgets/core/data/detections_panel.py
+++ b/vista/widgets/core/data/detections_panel.py
@@ -1031,7 +1031,6 @@ class DetectionsPanel(DataPanel):
         if selected_detector_uuids:
             self._select_detectors_by_uuid(selected_detector_uuids)
 
-        self.viewer.update_overlays()  # Refresh viewer to show changes
         self.data_changed.emit()
 
     def _select_detectors_by_uuid(self, detector_uuids):
@@ -1593,9 +1592,6 @@ class DetectionsPanel(DataPanel):
         # Clear our selection
         self.clear_detection_selection()
 
-        # Update viewer display
-        self.viewer.update_overlays()
-
         # Refresh the table
         self.refresh_detections_table()
 
@@ -1664,9 +1660,6 @@ class DetectionsPanel(DataPanel):
 
         # Clear selection
         self.clear_detection_selection()
-
-        # Refresh displays
-        self.viewer.update_overlays()
 
         # Explicitly refresh the tracks table to show the new track
         # Get the tracks panel from the parent data manager
@@ -1809,7 +1802,6 @@ class DetectionsPanel(DataPanel):
             self.cancel_add_to_existing_track()
 
             # Refresh displays
-            self.viewer.update_overlays()
             self.data_changed.emit()
 
             # Exit detection selection mode
@@ -1988,7 +1980,6 @@ class DetectionsPanel(DataPanel):
         self.viewer.detectors = snapshot.data
         self.clear_detection_selection()
 
-        self.viewer.update_overlays()
         self.refresh_detections_table()
         self.data_changed.emit()
 

--- a/vista/widgets/core/data/known_sources_panel.py
+++ b/vista/widgets/core/data/known_sources_panel.py
@@ -83,7 +83,7 @@ class KnownSourcesPanel(DataPanel):
 
             # Name (editable)
             name_item = QTableWidgetItem(source.name)
-            name_item.setData(Qt.ItemDataRole.UserRole, source.uuid)  # Store AOI UUID
+            name_item.setData(Qt.ItemDataRole.UserRole, source.uuid)  # Store KnownSource UUID
             self.known_sources_table.setItem(row, 0, name_item)
 
             # Source Types (read-only)

--- a/vista/widgets/core/data/known_sources_panel.py
+++ b/vista/widgets/core/data/known_sources_panel.py
@@ -135,16 +135,16 @@ class KnownSourcesPanel(DataPanel):
                         break
 
         # Create the tracks
-        total_tracks = 0
+        all_tracks = []
         for source in known_sources:
             tracks = source.create_tracks(self.viewer.imagery)
-            self.viewer.add_tracks(tracks)
-            total_tracks += len(tracks)
+            all_tracks += tracks
+        self.viewer.add_tracks(all_tracks)
 
         self.data_changed.emit()
 
         QMessageBox.information(
-            self, "Tracks Created", f"Created {total_tracks} Track(s) from {len(known_sources)} Known Source(s)."
+            self, "Tracks Created", f"Created {len(all_tracks)} Track(s) from {len(known_sources)} Known Source(s)."
         )
 
     def delete_selected_known_sources(self):

--- a/vista/widgets/core/data/tracks_panel.py
+++ b/vista/widgets/core/data/tracks_panel.py
@@ -4,7 +4,7 @@ import pathlib
 
 import numpy as np
 import pandas as pd
-from PyQt6.QtCore import QEvent, QSettings, Qt
+from PyQt6.QtCore import QEvent, QItemSelectionModel, QSettings, Qt
 from PyQt6.QtGui import QAction, QBrush, QColor
 from PyQt6.QtWidgets import (
     QApplication,
@@ -30,7 +30,6 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QTableWidget,
     QTableWidgetItem,
-    QTableWidgetSelectionRange,
     QVBoxLayout,
     QWidget,
 )
@@ -2376,15 +2375,18 @@ class TracksPanel(DataPanel):
         """
         self.tracks_table.blockSignals(True)
         self.tracks_table.clearSelection()
+        selection_model = self.tracks_table.selectionModel()
+        model = self.tracks_table.model()
 
         for row in range(self.tracks_table.rowCount()):
             track_name_item = self.tracks_table.item(row, 2)  # Track name column
             if track_name_item:
                 track_uuid = track_name_item.data(Qt.ItemDataRole.UserRole)
                 if track_uuid in track_uuids:
-                    # select all items in the row
-                    row_range = QTableWidgetSelectionRange(row, 0, row, self.tracks_table.columnCount() - 1)
-                    self.tracks_table.setRangeSelected(row_range, True)
+                    index = model.index(row, 0)
+                    selection_model.select(
+                        index, QItemSelectionModel.SelectionFlag.Select | QItemSelectionModel.SelectionFlag.Rows
+                    )
 
         self.tracks_table.blockSignals(False)
         self.on_track_selection_changed()  # Trigger selection changed handler

--- a/vista/widgets/core/data/tracks_panel.py
+++ b/vista/widgets/core/data/tracks_panel.py
@@ -1695,12 +1695,10 @@ class TracksPanel(DataPanel):
             if track.has_uncertainty():
                 item = self.tracks_table.item(row, column)
                 track.show_uncertainty = item.checkState() == Qt.CheckState.Checked
-                self.viewer.update_overlays()  # Refresh viewer to show/hide uncertainty ellipses
 
         # Invalidate caches if styling properties were modified
         if column in [5, 6, 7, 8, 12]:  # Color, Marker, Line Width, Marker Size, Line Style
             track.invalidate_caches()
-            self.viewer.update_overlays()  # Refresh viewer to show styling changes
 
         self.data_changed.emit()
 
@@ -1916,7 +1914,6 @@ class TracksPanel(DataPanel):
         if selected_track_uuids:
             self.select_tracks_by_uuid(selected_track_uuids)
 
-        self.viewer.update_overlays()  # Refresh viewer to show changes
         self.data_changed.emit()
 
     def merge_selected_tracks(self):
@@ -2022,9 +2019,6 @@ class TracksPanel(DataPanel):
                     self.viewer.plot_item.removeItem(ellipse)
                 del self.viewer.track_uncertainty_items[track_id]
 
-        # Update the viewer to create plot items for the new merged track
-        self.viewer.update_overlays()
-
         # Refresh table
         self.refresh_tracks_table()
         self.data_changed.emit()
@@ -2127,9 +2121,6 @@ class TracksPanel(DataPanel):
         second_track.tracker = track_to_split.tracker
         self.viewer.tracks.append(first_track)
         self.viewer.tracks.append(second_track)
-
-        # Update the viewer to create plot items for the new tracks
-        self.viewer.update_overlays()
 
         # Refresh table
         self.refresh_tracks_table()
@@ -3086,7 +3077,6 @@ class TracksPanel(DataPanel):
         self.viewer.tracks = snapshot.data
         self.viewer.selected_track_ids.clear()
 
-        self.viewer.update_overlays()
         self.refresh_tracks_table()
         self.data_changed.emit()
 

--- a/vista/widgets/core/data/tracks_panel.py
+++ b/vista/widgets/core/data/tracks_panel.py
@@ -30,6 +30,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QTableWidget,
     QTableWidgetItem,
+    QTableWidgetSelectionRange,
     QVBoxLayout,
     QWidget,
 )
@@ -2381,11 +2382,9 @@ class TracksPanel(DataPanel):
             if track_name_item:
                 track_uuid = track_name_item.data(Qt.ItemDataRole.UserRole)
                 if track_uuid in track_uuids:
-                    # Manually select all items in the row to ensure multiple rows can be selected
-                    for col in range(self.tracks_table.columnCount()):
-                        item = self.tracks_table.item(row, col)
-                        if item:
-                            item.setSelected(True)
+                    # select all items in the row
+                    row_range = QTableWidgetSelectionRange(row, 0, row, self.tracks_table.columnCount() - 1)
+                    self.tracks_table.setRangeSelected(row_range, True)
 
         self.tracks_table.blockSignals(False)
         self.on_track_selection_changed()  # Trigger selection changed handler

--- a/vista/widgets/core/imagery_viewer.py
+++ b/vista/widgets/core/imagery_viewer.py
@@ -795,13 +795,17 @@ class ImageryViewer(QWidget):
 
             # Filter by sensor if one is selected
             if self.selected_sensor is not None and track.sensor != self.selected_sensor:
-                path.setData(x=[], y=[])  # Hide track from different sensor
-                marker.setData(x=[], y=[])
-                # Clear uncertainty ellipses for this track
-                if track_id in self.track_uncertainty_items:
-                    for item in self.track_uncertainty_items[track_id]:
-                        self.plot_item.removeItem(item)
-                    del self.track_uncertainty_items[track_id]
+                # if path or marker is visible, hide them so future loops don't touch them and quickly continue
+                if path.isVisible() or marker.isVisible():
+                    # we don't bother clearing out coordinates, since if these items are shown
+                    # in the future when the sensor is changed, coordinates will be recalculated
+                    path.hide()
+                    marker.hide()
+                    # Clear uncertainty ellipses for this track
+                    if track_id in self.track_uncertainty_items:
+                        for item in self.track_uncertainty_items[track_id]:
+                            self.plot_item.removeItem(item)
+                        del self.track_uncertainty_items[track_id]
                 continue
 
             # Update visibility
@@ -809,6 +813,11 @@ class ImageryViewer(QWidget):
                 path.setData(x=[], y=[])
                 marker.setData(x=[], y=[])
                 continue
+
+            # if path or marker were previously hidden, make them visible
+            if not path.isVisible() or not marker.isVisible():
+                path.show()
+                marker.show()
 
             # Check if track is selected for highlighting
             is_selected = track_id in self.selected_track_ids

--- a/vista/widgets/core/main_window.py
+++ b/vista/widgets/core/main_window.py
@@ -3121,9 +3121,7 @@ class VistaMainWindow(QMainWindow):
         if tracks is not None:
             # Convert single item to list
             tracks_list = [tracks] if isinstance(tracks, Track) else tracks
-
-            for track in tracks_list:
-                self.viewer.add_track(track)
+            self.viewer.add_tracks(tracks_list)
 
         # Update playback controls with new frame range
         min_frame, max_frame = self.viewer.get_frame_range()


### PR DESCRIPTION
When a large number of tracks (total, over all sensors) are loaded, rendering can be slowed down as the update_overlays function loops over every track. 

Previously, if a track did not belong to the current sensor, its path and marker coordinates were updated to empty lists every time update_overlays is called. Even though there are no coordinates to paint, the items are still flagged visible and have some rendering overhead.

Now, the first time update_overlays is called and a track doesn't belong to the currently selected sensor, its plot items are hidden. Future calls to update_overlays (without changing the sensor!) then quickly skip those paths and markers in the rendering queue.

The next time the sensor is changed however, the relevant plot items for its tracks are reshown.