### PR TITLE
Feature/display filenames

### DIFF
--- a/vista/imagery/imagery.py
+++ b/vista/imagery/imagery.py
@@ -67,6 +67,8 @@ class Imagery:
     -------------------
     description : str, optional
         Long-form description of the imagery (default: "")
+    filename : str, optional
+        Filename the imagery was loaded from
     _histograms : dict, optional
         Cached histograms for performance. Maps frame_index -> (hist_y, hist_x).
         Computed lazily via get_histogram() method.
@@ -132,6 +134,7 @@ class Imagery:
     _histograms: Optional[dict] = None  # Maps frame_index -> (hist_y, hist_x)
     default_histogram_bounds: Optional[dict] = None  # Maps frame_index -> (min, max)
     uuid: str = field(init=None, default=None)
+    filename: str = ""  # filename where this imagery came from
 
     # Incremental loading support: tracks how many frames have valid image data.
     # None = fully loaded (default for programmatically created imagery).

--- a/vista/sensors/sensor.py
+++ b/vista/sensors/sensor.py
@@ -140,6 +140,7 @@ class Sensor:
         """
         if (imagery.uuid in self._added_imagery_uuids) or (imagery.times is None):
             return
+        self._added_imagery_uuids.append(imagery.uuid)
         self._imagery_frames_dataframe = pd.concat(
             (self._imagery_frames_dataframe, pd.DataFrame({"frames": imagery.frames, "times": imagery.times}))
         )

--- a/vista/widgets/core/data/data_loader.py
+++ b/vista/widgets/core/data/data_loader.py
@@ -388,7 +388,11 @@ class DataLoaderThread(QThread):
 
         # Restore UUID if present in file, otherwise keep auto-generated UUID
         if imagery_uuid is not None:
+            # remove auto-generated uuid
+            sensor._added_imagery_uuids.remove(imagery.uuid)
             imagery.uuid = uuid.UUID(imagery_uuid)
+            # and add back in the correct one
+            sensor._added_imagery_uuids.append(imagery.uuid)
 
         # Load images incrementally, emitting signals as blocks become available
         self._load_images_incrementally(imagery, images_dataset, sensor)

--- a/vista/widgets/core/data/data_loader.py
+++ b/vista/widgets/core/data/data_loader.py
@@ -185,6 +185,7 @@ class DataLoaderThread(QThread):
             row_offset=row_offset,
             column_offset=column_offset,
             times=times,
+            filename=self.file_path,
         )
         imagery.loaded_frame_count = 0
 
@@ -381,6 +382,7 @@ class DataLoaderThread(QThread):
             column_offset=column_offset,
             times=times,
             description=description,
+            filename=str(self.file_path),
         )
         imagery.loaded_frame_count = 0
 

--- a/vista/widgets/core/data/data_loader.py
+++ b/vista/widgets/core/data/data_loader.py
@@ -382,7 +382,7 @@ class DataLoaderThread(QThread):
             column_offset=column_offset,
             times=times,
             description=description,
-            filename=str(self.file_path),
+            filename=self.file_path,
         )
         imagery.loaded_frame_count = 0
 

--- a/vista/widgets/core/data/imagery_panel.py
+++ b/vista/widgets/core/data/imagery_panel.py
@@ -1,5 +1,7 @@
 """Imagery panel for data manager"""
 
+from pathlib import Path
+
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
     QHBoxLayout,
@@ -68,11 +70,6 @@ class ImageryPanel(DataPanel):
         # Opacity column is hidden by default (shown only in map view)
         self.imagery_table.setColumnHidden(3, True)
 
-        # make name column resizeable, after everything is fit to window initially above
-        width = self.imagery_table.columnWidth(0)
-        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Interactive)
-        self.imagery_table.setColumnWidth(0, width)
-
         self.imagery_table.itemSelectionChanged.connect(self.on_imagery_selection_changed)
         self.imagery_table.cellChanged.connect(self.on_imagery_cell_changed)
 
@@ -131,9 +128,11 @@ class ImageryPanel(DataPanel):
             opacity_spinbox.valueChanged.connect(lambda val, uid=imagery.uuid: self._on_opacity_changed(uid, val))
             self.imagery_table.setCellWidget(row, 3, opacity_spinbox)
 
-            imagery_fname_item = QTableWidgetItem(imagery.filename)
+            fname = imagery.filename
+            imagery_fname_item = QTableWidgetItem(Path(fname).stem)
             imagery_fname_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
             self.imagery_table.setItem(row, 4, imagery_fname_item)
+            imagery_fname_item.setToolTip(fname)
 
         self.imagery_table.blockSignals(False)
 

--- a/vista/widgets/core/data/imagery_panel.py
+++ b/vista/widgets/core/data/imagery_panel.py
@@ -50,8 +50,8 @@ class ImageryPanel(DataPanel):
 
         # Imagery table
         self.imagery_table = QTableWidget()
-        self.imagery_table.setColumnCount(4)
-        self.imagery_table.setHorizontalHeaderLabels(["Name", "Frames", "GPU", "Opacity"])
+        self.imagery_table.setColumnCount(5)
+        self.imagery_table.setHorizontalHeaderLabels(["Name", "Frames", "GPU", "Opacity", "File Location"])
 
         # Enable row selection via vertical header (single selection only)
         self.imagery_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
@@ -63,9 +63,15 @@ class ImageryPanel(DataPanel):
         header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)  # Frames (numeric)
         header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)  # GPU device
         header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)  # Opacity
+        header.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)  # File Location
 
         # Opacity column is hidden by default (shown only in map view)
         self.imagery_table.setColumnHidden(3, True)
+
+        # make name column resizeable, after everything is fit to window initially above
+        width = self.imagery_table.columnWidth(0)
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Interactive)
+        self.imagery_table.setColumnWidth(0, width)
 
         self.imagery_table.itemSelectionChanged.connect(self.on_imagery_selection_changed)
         self.imagery_table.cellChanged.connect(self.on_imagery_cell_changed)
@@ -124,6 +130,10 @@ class ImageryPanel(DataPanel):
             opacity_spinbox.setToolTip("Imagery opacity in map view")
             opacity_spinbox.valueChanged.connect(lambda val, uid=imagery.uuid: self._on_opacity_changed(uid, val))
             self.imagery_table.setCellWidget(row, 3, opacity_spinbox)
+
+            imagery_fname_item = QTableWidgetItem(imagery.filename)
+            imagery_fname_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            self.imagery_table.setItem(row, 4, imagery_fname_item)
 
         self.imagery_table.blockSignals(False)
 

--- a/vista/widgets/core/data/sensors_panel.py
+++ b/vista/widgets/core/data/sensors_panel.py
@@ -112,6 +112,7 @@ class SensorsPanel(DataPanel):
                 for imagery in self.viewer.imageries:
                     if imagery.uuid in sensor._added_imagery_uuids:
                         loaded_imagery_fnames.append(imagery.filename)
+            loaded_imagery_fnames = list(set(loaded_imagery_fnames))  # list of unique fnames
             loaded_imagery_fname_item = QTableWidgetItem(str([Path(fname).stem for fname in loaded_imagery_fnames]))
             loaded_imagery_fname_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
             self.sensors_table.setItem(row, 5, loaded_imagery_fname_item)

--- a/vista/widgets/core/data/sensors_panel.py
+++ b/vista/widgets/core/data/sensors_panel.py
@@ -113,10 +113,11 @@ class SensorsPanel(DataPanel):
                     if imagery.uuid in sensor._added_imagery_uuids:
                         loaded_imagery_fnames.append(imagery.filename)
             loaded_imagery_fnames = list(set(loaded_imagery_fnames))  # list of unique fnames
-            loaded_imagery_fname_item = QTableWidgetItem(str([Path(fname).stem for fname in loaded_imagery_fnames]))
+            short_names = [Path(fname).stem for fname in loaded_imagery_fnames]  # just use stem for display
+            loaded_imagery_fname_item = QTableWidgetItem(", ".join(short_names))
             loaded_imagery_fname_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
             self.sensors_table.setItem(row, 5, loaded_imagery_fname_item)
-            loaded_imagery_fname_item.setToolTip("\n".join(loaded_imagery_fnames))
+            loaded_imagery_fname_item.setToolTip("\n".join(loaded_imagery_fnames))  # but full path for tooltip
 
         self.sensors_table.blockSignals(False)
 

--- a/vista/widgets/core/data/sensors_panel.py
+++ b/vista/widgets/core/data/sensors_panel.py
@@ -40,9 +40,9 @@ class SensorsPanel(DataPanel):
 
         # Sensors table
         self.sensors_table = QTableWidget()
-        self.sensors_table.setColumnCount(5)
+        self.sensors_table.setColumnCount(6)
         self.sensors_table.setHorizontalHeaderLabels(
-            ["Name", "Geolocation", "Bias Images", "Uniformity Gain", "Bad Pixel Mask"]
+            ["Name", "Geolocation", "Bias Images", "Uniformity Gain", "Bad Pixel Mask", "Imagery File Location(s)"]
         )
 
         # Enable row selection (single selection only)
@@ -56,6 +56,12 @@ class SensorsPanel(DataPanel):
         header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)  # Bias Images
         header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)  # Uniformity Gain
         header.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)  # Bad Pixel Mask
+        header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)  # Imagery File Location(s)
+
+        # make name column resizeable, after everything is fit to window initially above
+        width = self.sensors_table.columnWidth(0)
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Interactive)
+        self.sensors_table.setColumnWidth(0, width)
 
         self.sensors_table.itemSelectionChanged.connect(self.on_sensor_selection_changed)
 
@@ -102,6 +108,16 @@ class SensorsPanel(DataPanel):
             bad_pixel_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
             bad_pixel_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.sensors_table.setItem(row, 4, bad_pixel_item)
+
+            # Loaded imagery filename(s) (not editable)
+            loaded_imagery_fnames = []
+            if sensor._added_imagery_uuids:
+                for imagery in self.viewer.imageries:
+                    if imagery.uuid in sensor._added_imagery_uuids:
+                        loaded_imagery_fnames.append(imagery.filename)
+            loaded_imagery_fname_item = QTableWidgetItem(str(loaded_imagery_fnames))
+            loaded_imagery_fname_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            self.sensors_table.setItem(row, 5, loaded_imagery_fname_item)
 
         self.sensors_table.blockSignals(False)
 

--- a/vista/widgets/core/data/sensors_panel.py
+++ b/vista/widgets/core/data/sensors_panel.py
@@ -1,5 +1,7 @@
 """Sensors panel for data manager"""
 
+from pathlib import Path
+
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
     QHBoxLayout,
@@ -58,11 +60,6 @@ class SensorsPanel(DataPanel):
         header.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)  # Bad Pixel Mask
         header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)  # Imagery File Location(s)
 
-        # make name column resizeable, after everything is fit to window initially above
-        width = self.sensors_table.columnWidth(0)
-        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Interactive)
-        self.sensors_table.setColumnWidth(0, width)
-
         self.sensors_table.itemSelectionChanged.connect(self.on_sensor_selection_changed)
 
         layout.addWidget(self.sensors_table)
@@ -115,9 +112,10 @@ class SensorsPanel(DataPanel):
                 for imagery in self.viewer.imageries:
                     if imagery.uuid in sensor._added_imagery_uuids:
                         loaded_imagery_fnames.append(imagery.filename)
-            loaded_imagery_fname_item = QTableWidgetItem(str(loaded_imagery_fnames))
+            loaded_imagery_fname_item = QTableWidgetItem(str([Path(fname).stem for fname in loaded_imagery_fnames]))
             loaded_imagery_fname_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
             self.sensors_table.setItem(row, 5, loaded_imagery_fname_item)
+            loaded_imagery_fname_item.setToolTip("\n".join(loaded_imagery_fnames))
 
         self.sensors_table.blockSignals(False)
 


### PR DESCRIPTION
When loading in simulated data from multiple files that share a common sensor name (but different sensor uuids), it can be helpful to have the filename visible to disambiguate quickly between the various rows of sensors.

This pull request adds a "File location" column to the sensor and imagery tabs of the data manager. The column displays a short version (the stem) of the filename, while hovering over the cell with your mouse will display a tooltip with the full path name.