### PR TITLE
Bugfix/panels

### DIFF
--- a/vista/widgets/core/data/aois_panel.py
+++ b/vista/widgets/core/data/aois_panel.py
@@ -118,9 +118,7 @@ class AOIsPanel(DataPanel):
             # Select row if AOI is marked as selected
             if hasattr(aoi, "_selected") and aoi._selected:
                 index = model.index(row, 0)
-                selection_model.select(
-                    index, selection_model.SelectionFlag.Select | selection_model.SelectionFlag.Rows
-                )
+                selection_model.select(index, selection_model.SelectionFlag.Select | selection_model.SelectionFlag.Rows)
 
         self.aois_table.blockSignals(False)
         self.on_aoi_selection_changed()

--- a/vista/widgets/core/data/aois_panel.py
+++ b/vista/widgets/core/data/aois_panel.py
@@ -90,11 +90,14 @@ class AOIsPanel(DataPanel):
     def clear_selection(self):
         """Clear all AOI selections in the table, which deselects AOIs in the viewer"""
         self.aois_table.clearSelection()
+        self.on_aoi_selection_changed()
 
     def refresh_aois_table(self):
         """Refresh the AOIs table"""
         self.aois_table.blockSignals(True)
         self.aois_table.setRowCount(0)
+        selection_model = self.aois_table.selectionModel()
+        model = self.aois_table.model()
 
         for row, aoi in enumerate(self.viewer.aois):
             self.aois_table.insertRow(row)
@@ -110,12 +113,15 @@ class AOIsPanel(DataPanel):
             bounds_item.setFlags(bounds_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
             self.aois_table.setItem(row, 1, bounds_item)
 
-        self.aois_table.blockSignals(False)
-
-        # Select rows for AOIs that are marked as selected
-        for row, aoi in enumerate(self.viewer.aois):
+            # Select row if AOIs is marked as selected
             if hasattr(aoi, "_selected") and aoi._selected:
-                self.aois_table.selectRow(row)
+                index = model.index(row, 0)
+                selection_model.select(
+                    index, selection_model.SelectionFlag.Select | selection_model.SelectionFlag.Rows
+                )
+
+        self.aois_table.blockSignals(False)
+        self.on_aoi_selection_changed()
 
     def on_aoi_selection_changed(self):
         """Handle AOI selection changes from table"""

--- a/vista/widgets/core/data/aois_panel.py
+++ b/vista/widgets/core/data/aois_panel.py
@@ -39,11 +39,13 @@ class AOIsPanel(DataPanel):
         self.delete_aoi_btn = QPushButton("Delete Selected")
         self.delete_aoi_btn.clicked.connect(self.delete_selected_aois)
         button_layout.addWidget(self.delete_aoi_btn)
+        self.delete_aoi_btn.setEnabled(False)
 
         # Export button
         self.export_aoi_btn = QPushButton("Export Selection")
         self.export_aoi_btn.clicked.connect(self.export_aois)
         button_layout.addWidget(self.export_aoi_btn)
+        self.export_aoi_btn.setEnabled(False)
 
         button_layout.addStretch()
         layout.addLayout(button_layout)
@@ -119,6 +121,10 @@ class AOIsPanel(DataPanel):
         """Handle AOI selection changes from table"""
         # Get selected rows
         selected_rows = set(index.row() for index in self.aois_table.selectedIndexes())
+
+        has_selection = len(selected_rows) > 0
+        self.delete_aoi_btn.setEnabled(has_selection)
+        self.export_aoi_btn.setEnabled(has_selection)
 
         # Update all AOIs selectability based on selection
         for row, aoi in enumerate(self.viewer.aois):

--- a/vista/widgets/core/data/aois_panel.py
+++ b/vista/widgets/core/data/aois_panel.py
@@ -72,6 +72,8 @@ class AOIsPanel(DataPanel):
         header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Bounds (read-only)
 
         self.aois_table.cellChanged.connect(self.on_aoi_cell_changed)
+        # Enable Delete and Export buttons when rows are selected
+        # Also updates AOI selectability in the viewer
         self.aois_table.itemSelectionChanged.connect(self.on_aoi_selection_changed)
 
         layout.addWidget(self.aois_table)
@@ -113,7 +115,7 @@ class AOIsPanel(DataPanel):
             bounds_item.setFlags(bounds_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
             self.aois_table.setItem(row, 1, bounds_item)
 
-            # Select row if AOIs is marked as selected
+            # Select row if AOI is marked as selected
             if hasattr(aoi, "_selected") and aoi._selected:
                 index = model.index(row, 0)
                 selection_model.select(

--- a/vista/widgets/core/data/features_panel.py
+++ b/vista/widgets/core/data/features_panel.py
@@ -55,7 +55,7 @@ class FeaturesPanel(DataPanel):
         self.features_table.setHorizontalHeaderLabels(["Visible", "Name", "Type"])
 
         # Enable Delete button when rows are selected
-        self.features_table.itemSelectionChanged.connect(self.on_selection_changed)
+        self.features_table.itemSelectionChanged.connect(self.on_feature_selection_changed)
 
         # Enable row selection via vertical header
         self.features_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
@@ -82,7 +82,7 @@ class FeaturesPanel(DataPanel):
         backspace_shortcut.setContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
         backspace_shortcut.activated.connect(self.delete_selected_features)
 
-    def on_selection_changed(self):
+    def on_feature_selection_changed(self):
         """Enable or disable buttons based on selection"""
         selected_rows = self.features_table.selectionModel().selectedRows()
         has_selection = len(selected_rows) > 0
@@ -119,7 +119,7 @@ class FeaturesPanel(DataPanel):
             self.features_table.setItem(row, 2, type_item)
 
         self.features_table.blockSignals(False)
-        self.on_selection_changed()
+        self.on_feature_selection_changed()
 
     def on_feature_visibility_changed(self, feature, state):
         """Handle feature visibility checkbox changes"""
@@ -192,7 +192,7 @@ class FeaturesPanel(DataPanel):
                     )
 
         self.features_table.blockSignals(False)
-        self.on_selection_changed()
+        self.on_feature_selection_changed()
 
     def create_placemark(self):
         """Open dialog to create a new placemark"""

--- a/vista/widgets/core/data/features_panel.py
+++ b/vista/widgets/core/data/features_panel.py
@@ -178,13 +178,18 @@ class FeaturesPanel(DataPanel):
         feature_uuids = {feature.uuid for feature in features}
         self.features_table.blockSignals(True)
         self.features_table.clearSelection()
+        selection_model = self.features_table.selectionModel()
+        model = self.features_table.model()
 
         for row in range(self.features_table.rowCount()):
             name_item = self.features_table.item(row, 1)  # Name column
             if name_item:
                 uuid = name_item.data(Qt.ItemDataRole.UserRole)
                 if uuid in feature_uuids:
-                    self.features_table.selectRow(row)
+                    index = model.index(row, 0)
+                    selection_model.select(
+                        index, selection_model.SelectionFlag.Select | selection_model.SelectionFlag.Rows
+                    )
 
         self.features_table.blockSignals(False)
         self.on_selection_changed()

--- a/vista/widgets/core/data/features_panel.py
+++ b/vista/widgets/core/data/features_panel.py
@@ -54,6 +54,9 @@ class FeaturesPanel(DataPanel):
         self.features_table.setColumnCount(3)
         self.features_table.setHorizontalHeaderLabels(["Visible", "Name", "Type"])
 
+        # Enable Delete and Create Tracks buttons when rows are selected
+        self.features_table.itemSelectionChanged.connect(self.on_selection_changed)
+
         # Enable row selection via vertical header
         self.features_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self.features_table.setSelectionMode(QTableWidget.SelectionMode.ExtendedSelection)
@@ -78,6 +81,12 @@ class FeaturesPanel(DataPanel):
         backspace_shortcut = QShortcut(QKeySequence(Qt.Key.Key_Backspace), self)
         backspace_shortcut.setContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
         backspace_shortcut.activated.connect(self.delete_selected_features)
+
+    def on_selection_changed(self):
+        """Enable or disable buttons based on selection"""
+        selected_rows = self.features_table.selectionModel().selectedRows()
+        has_selection = len(selected_rows) > 0
+        self.delete_feature_btn.setEnabled(has_selection)
 
     def refresh_features_table(self):
         """Refresh the features table"""
@@ -111,6 +120,7 @@ class FeaturesPanel(DataPanel):
                 self.features_table.setItem(row, 2, type_item)
 
         self.features_table.blockSignals(False)
+        self.on_selection_changed()
 
     def on_feature_visibility_changed(self, feature, state):
         """Handle feature visibility checkbox changes"""
@@ -178,6 +188,7 @@ class FeaturesPanel(DataPanel):
                     self.features_table.selectRow(row)
 
         self.features_table.blockSignals(False)
+        self.on_selection_changed()
 
     def create_placemark(self):
         """Open dialog to create a new placemark"""

--- a/vista/widgets/core/data/features_panel.py
+++ b/vista/widgets/core/data/features_panel.py
@@ -54,7 +54,7 @@ class FeaturesPanel(DataPanel):
         self.features_table.setColumnCount(3)
         self.features_table.setHorizontalHeaderLabels(["Visible", "Name", "Type"])
 
-        # Enable Delete and Create Tracks buttons when rows are selected
+        # Enable Delete button when rows are selected
         self.features_table.itemSelectionChanged.connect(self.on_selection_changed)
 
         # Enable row selection via vertical header

--- a/vista/widgets/core/data/features_panel.py
+++ b/vista/widgets/core/data/features_panel.py
@@ -93,31 +93,30 @@ class FeaturesPanel(DataPanel):
         self.features_table.blockSignals(True)
         self.features_table.setRowCount(0)
 
-        if hasattr(self.viewer, "features"):
-            for row, feature in enumerate(self.viewer.features):
-                self.features_table.insertRow(row)
+        for row, feature in enumerate(self.viewer.features):
+            self.features_table.insertRow(row)
 
-                # Visible checkbox
-                checkbox = QCheckBox()
-                checkbox.setChecked(feature.visible)
-                checkbox.stateChanged.connect(lambda state, f=feature: self.on_feature_visibility_changed(f, state))
-                # Center the checkbox in the cell
-                checkbox_widget = QWidget()
-                checkbox_layout = QHBoxLayout(checkbox_widget)
-                checkbox_layout.addWidget(checkbox)
-                checkbox_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                checkbox_layout.setContentsMargins(0, 0, 0, 0)
-                self.features_table.setCellWidget(row, 0, checkbox_widget)
+            # Visible checkbox
+            checkbox = QCheckBox()
+            checkbox.setChecked(feature.visible)
+            checkbox.stateChanged.connect(lambda state, f=feature: self.on_feature_visibility_changed(f, state))
+            # Center the checkbox in the cell
+            checkbox_widget = QWidget()
+            checkbox_layout = QHBoxLayout(checkbox_widget)
+            checkbox_layout.addWidget(checkbox)
+            checkbox_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            checkbox_layout.setContentsMargins(0, 0, 0, 0)
+            self.features_table.setCellWidget(row, 0, checkbox_widget)
 
-                # Name (editable)
-                name_item = QTableWidgetItem(feature.name)
-                name_item.setData(Qt.ItemDataRole.UserRole, feature.uuid)  # Store feature UUID
-                self.features_table.setItem(row, 1, name_item)
+            # Name (editable)
+            name_item = QTableWidgetItem(feature.name)
+            name_item.setData(Qt.ItemDataRole.UserRole, feature.uuid)  # Store feature UUID
+            self.features_table.setItem(row, 1, name_item)
 
-                # Type (read-only)
-                type_item = QTableWidgetItem(feature.feature_type)
-                type_item.setFlags(type_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
-                self.features_table.setItem(row, 2, type_item)
+            # Type (read-only)
+            type_item = QTableWidgetItem(feature.feature_type)
+            type_item.setFlags(type_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            self.features_table.setItem(row, 2, type_item)
 
         self.features_table.blockSignals(False)
         self.on_selection_changed()

--- a/vista/widgets/core/data/features_panel.py
+++ b/vista/widgets/core/data/features_panel.py
@@ -35,15 +35,16 @@ class FeaturesPanel(DataPanel):
         # Button bar for actions
         button_layout = QHBoxLayout()
 
-        # Create Placemark button
-        self.create_placemark_btn = QPushButton("Create Placemark")
-        self.create_placemark_btn.clicked.connect(self.create_placemark)
-        button_layout.addWidget(self.create_placemark_btn)
-
         # Delete button
         self.delete_feature_btn = QPushButton("Delete Selected")
         self.delete_feature_btn.clicked.connect(self.delete_selected_features)
         button_layout.addWidget(self.delete_feature_btn)
+        self.delete_feature_btn.setEnabled(False)
+
+        # Create Placemark button
+        self.create_placemark_btn = QPushButton("Create Placemark")
+        self.create_placemark_btn.clicked.connect(self.create_placemark)
+        button_layout.addWidget(self.create_placemark_btn)
 
         button_layout.addStretch()
         layout.addLayout(button_layout)

--- a/vista/widgets/core/imagery_viewer.py
+++ b/vista/widgets/core/imagery_viewer.py
@@ -1692,7 +1692,6 @@ class ImageryViewer(QWidget):
 
         # Store references
         aoi._roi_item = roi
-        aoi._selected = True  # Mark as selected
         self.aois.append(aoi)
 
         # Add text label
@@ -1770,7 +1769,6 @@ class ImageryViewer(QWidget):
             roi = pg.RectROI(pos, size, pen=pg.mkPen(aoi.color, width=2), snapSize=1.0)
             self.plot_item.addItem(roi)
             aoi._roi_item = roi
-            aoi._selected = False  # Start unselected
 
             # Add text label
             text_item = pg.TextItem(text=aoi.name, color=aoi.color, anchor=(0, 0))
@@ -1792,6 +1790,7 @@ class ImageryViewer(QWidget):
 
     def set_aoi_selectable(self, aoi: AOI, selectable: bool):
         """Set whether an AOI can be moved/resized"""
+        aoi._selected = selectable
         if aoi._roi_item:
             # Enable/disable translation (moving)
             aoi._roi_item.translatable = selectable


### PR DESCRIPTION
Attempting to select multiple features/placemarks with the lasso tool only results in the final item in the Features panel table being highlighted (despite the underlying lasso correctly passing a list of features to select). This means that multiple features cannot be selected via the lasso tool and bulk deleted.

The underlying cause is that the QTableWidget uses selectRow, which clears any previous selections when called, inside a loop. This PR swaps to using the table's selectionModel to highlight multiple rows (as is done for other panels, e.g. Detections). 

The QTableWidget for the AOI panel also uses selectRow, which has been fixed in this PR as well. Furthermore, the underlying _selected property of AOIs is now properly updated inside the set_aoi_selectable function. Previously it was set once on creation and never changed. Together, this fixes a second bug where multiple AOIs could be selected to edit, but once a change was made to one, only the last item in the table remained selected and editable.

Lastly, we disable some buttons when tables are empty.