### PR TITLE
Fix track sensor stale reference during csv upload

### DIFF
--- a/vista/widgets/core/data/data_manager.py
+++ b/vista/widgets/core/data/data_manager.py
@@ -29,7 +29,6 @@ class DataManagerPanel(QWidget):
         super().__init__()
         self.viewer = viewer
         self.settings = QSettings("VISTA", "DataManager")
-        self.selected_sensor = None
         self.init_ui()
 
     def init_ui(self):
@@ -80,7 +79,6 @@ class DataManagerPanel(QWidget):
 
     def on_sensor_selected(self, sensor):
         """Handle sensor selection change"""
-        self.selected_sensor = sensor
         # Filter the viewer to show only data for selected sensor
         self.viewer.filter_by_sensor(sensor)
         # Refresh other panels to show only data for selected sensor

--- a/vista/widgets/core/data/known_sources_panel.py
+++ b/vista/widgets/core/data/known_sources_panel.py
@@ -58,9 +58,7 @@ class KnownSourcesTrackCreationThread(QThread):
                     self.creation_cancelled.emit()
                     return
 
-                self.progress_updated.emit(
-                    f"Creating tracks from {source.name} ({index} of {total_sources})..."
-                )
+                self.progress_updated.emit(f"Creating tracks from {source.name} ({index} of {total_sources})...")
                 source_tracks = source.create_tracks(self.imagery)
 
                 if self.isInterruptionRequested():
@@ -72,9 +70,7 @@ class KnownSourcesTrackCreationThread(QThread):
             self.tracks_created.emit(tracks)
         except Exception as error:
             traceback_string = traceback.format_exc()
-            self.error_occurred.emit(
-                f"Track creation failed: {str(error)}\n\nTraceback:\n{traceback_string}"
-            )
+            self.error_occurred.emit(f"Track creation failed: {str(error)}\n\nTraceback:\n{traceback_string}")
 
 
 class KnownSourcesPanel(DataPanel):

--- a/vista/widgets/core/data/sensors_panel.py
+++ b/vista/widgets/core/data/sensors_panel.py
@@ -204,6 +204,7 @@ class SensorsPanel(DataPanel):
 
             # Clear selected sensor
             self.selected_sensor = None
+            self.sensor_selected.emit(None)
 
             # Update viewer display if it was showing imagery from the deleted sensor
             if self.viewer.imagery is not None and self.viewer.imagery.sensor == sensor:

--- a/vista/widgets/core/main_window.py
+++ b/vista/widgets/core/main_window.py
@@ -1174,7 +1174,7 @@ class VistaMainWindow(QMainWindow):
             self.settings.setValue("last_detections_dir", str(Path(file_paths[0]).parent))
 
             # Get currently selected sensor from data manager
-            selected_sensor = self.data_manager.selected_sensor
+            selected_sensor = self.viewer.selected_sensor
 
             # Check if sensor is selected (required for detection association)
             if not selected_sensor:
@@ -1294,7 +1294,7 @@ class VistaMainWindow(QMainWindow):
             self.settings.setValue("last_tracks_dir", str(Path(file_paths[0]).parent))
 
             # Get currently selected sensor and imagery from data manager
-            selected_sensor = self.data_manager.selected_sensor
+            selected_sensor = self.viewer.selected_sensor
             selected_imagery = self.viewer.imagery
 
             # Check if any tracks need sensor or imagery for conversion


### PR DESCRIPTION
Tracks are required to be associated with a sensor. If a sensor does not exist when uploading a csv of tracks, a dummy sensor is created. If that dummy sensor is deleted, and then another csv is uploaded, the newly created tracks end up with no sensor due to a stale reference.

This is because inside the load_tracks_file function of the main window, a reference to data_manager.selected_sensor is used. However, the Data Manager's selected_sensor was not being updated when a sensor is deleted.

Furthermore, in nearly every other location in the code, it is the Imagery Viewer's selected_sensor that is used when trying to determine the currently active sensor. We therefore change the two locations that used the Data Manager's selected_sensor to point to the Imagery Viewer's selected_sensor instead, and remove the unnecessary selected_sensor property in the Data Manager.

We do still add the missing signal emit when the selected_sensor is set to None that would have also solved the problem without removing the Data Manager's selected_sensor, for completeness.

